### PR TITLE
Share acolormap in omp parallel for

### DIFF
--- a/libimagequant.c
+++ b/libimagequant.c
@@ -1256,7 +1256,7 @@ LIQ_NONNULL static float remap_to_palette(liq_image *const input_image, unsigned
     kmeans_init(map, max_threads, average_color);
 
     #pragma omp parallel for if (rows*cols > 3000) \
-        schedule(static) default(none) shared(average_color) reduction(+:remapping_error)
+        schedule(static) default(none) shared(acolormap) shared(average_color) reduction(+:remapping_error)
     for(int row = 0; row < rows; ++row) {
         const f_pixel *const row_pixels = liq_image_get_row_f(input_image, row);
         const f_pixel *const bg_pixels = input_image->background && acolormap[transparent_index].acolor.a < 1.f/256.f ? liq_image_get_row_f(input_image->background, row) : NULL;


### PR DESCRIPTION
Even though 'acolormap' is declared const and we use "default(none)",
GCC 6.3.0 does not infer "shared" for it; declare it explicitly.