### PR TITLE
Add pkgconfig generation for shared lib build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ JAVAINCLUDE = -I'$(JAVA_HOME)/include' -I'$(JAVA_HOME)/include/linux' -I'$(JAVA_
 DISTFILES = $(OBJS:.o=.c) *.h README.md CHANGELOG COPYRIGHT Makefile configure
 TARNAME = libimagequant-$(VERSION)
 TARFILE = $(TARNAME)-src.tar.bz2
+PKGCONFIG = imagequant.pc
 
 all: static
 
@@ -49,6 +50,8 @@ $(SHAREDOBJS):
 libimagequant.so: $(SHAREDOBJS)
 	$(CC) -shared -Wl,-soname,$(SHAREDLIB).$(SOVER) -o $(SHAREDLIB).$(SOVER) $^ $(LDFLAGS)
 	ln -fs $(SHAREDLIB).$(SOVER) $(SHAREDLIB)
+	sed -i "s#^prefix=.*#prefix=$(PREFIX)#" $(PKGCONFIG)
+        sed -i "s#^Version:.*#Version: $(VERSION)#" $(PKGCONFIG)
 
 libimagequant.dylib: $(SHAREDOBJS)
 	$(CC) -shared -o $(SHAREDLIB).$(SOVER) $^ $(LDFLAGS)

--- a/imagequant.pc
+++ b/imagequant.pc
@@ -1,0 +1,9 @@
+prefix=
+includedir=${prefix}/include
+libdir=libdir=${prefix}/lib
+
+Name: imagequant
+Description: Small, portable C library for high-quality conversion of RGBA images to 8-bit indexed-color (palette) images.
+Version: 
+Libs: -L${libdir} -limagequant
+Cflags: -I${includedir}


### PR DESCRIPTION
Hello.  This PR adds the generation of pkgconfig when building the shared library. This will be very useful for building packages for different distributives.
Thank you.