### PR TITLE
Use alloca for variable length arrays when compiling with MS compiler

### DIFF
--- a/kmeans.c
+++ b/kmeans.c
@@ -66,7 +66,7 @@ LIQ_PRIVATE void kmeans_finalize(colormap *map, const unsigned int max_threads, 
 LIQ_PRIVATE double kmeans_do_iteration(histogram *hist, colormap *const map, kmeans_callback callback)
 {
     const unsigned int max_threads = omp_get_max_threads();
-    kmeans_state average_color[(KMEANS_CACHE_LINE_GAP+map->colors) * max_threads];
+    LIQ_ARRAY(kmeans_state, average_color, (KMEANS_CACHE_LINE_GAP+map->colors) * max_threads);
     kmeans_init(map, max_threads, average_color);
     struct nearest_map *const n = nearest_init(map);
     hist_item *const achv = hist->achv;

--- a/libimagequant.c
+++ b/libimagequant.c
@@ -156,7 +156,7 @@ LIQ_NONNULL static void liq_verbose_printf(const liq_attr *context, const char *
         int required_space = vsnprintf(NULL, 0, fmt, va)+1; // +\0
         va_end(va);
 
-        char buf[required_space];
+        LIQ_ARRAY(char, buf, required_space);
         va_start(va, fmt);
         vsnprintf(buf, required_space, fmt, va);
         va_end(va);
@@ -1250,7 +1250,7 @@ LIQ_NONNULL static float remap_to_palette(liq_image *const input_image, unsigned
 
 
     const unsigned int max_threads = omp_get_max_threads();
-    kmeans_state average_color[(KMEANS_CACHE_LINE_GAP+map->colors) * max_threads];
+    LIQ_ARRAY(kmeans_state, average_color, (KMEANS_CACHE_LINE_GAP+map->colors) * max_threads);
     kmeans_init(map, max_threads, average_color);
 
     #pragma omp parallel for if (rows*cols > 3000) \
@@ -2049,7 +2049,7 @@ LIQ_EXPORT LIQ_NONNULL liq_error liq_write_remapped_image(liq_result *result, li
         return LIQ_BUFFER_TOO_SMALL;
     }
 
-    unsigned char *rows[input_image->height];
+    LIQ_ARRAY(unsigned char *, rows, input_image->height);
     unsigned char *buffer_bytes = buffer;
     for(unsigned int i=0; i < input_image->height; i++) {
         rows[i] = &buffer_bytes[input_image->width * i];

--- a/mediancut.c
+++ b/mediancut.c
@@ -325,7 +325,7 @@ static void box_init(struct box *box, const hist_item *achv, const unsigned int 
 LIQ_PRIVATE colormap *mediancut(histogram *hist, unsigned int newcolors, const double target_mse, const double max_mse, void* (*malloc)(size_t), void (*free)(void*))
 {
     hist_item *achv = hist->achv;
-    struct box bv[newcolors];
+    LIQ_ARRAY(struct box, bv, newcolors);
     unsigned int boxes = 1;
 
     /*

--- a/nearest.c
+++ b/nearest.c
@@ -110,7 +110,7 @@ LIQ_PRIVATE struct nearest_map *nearest_init(const colormap *map) {
     mempoolptr m = NULL;
     struct nearest_map *handle = mempool_create(&m, sizeof(handle[0]), sizeof(handle[0]) + sizeof(vp_node)*map->colors+16, map->malloc, map->free);
 
-    vp_sort_tmp indexes[map->colors];
+    LIQ_ARRAY(vp_sort_tmp, indexes, map->colors);
 
     for(unsigned int i=0; i < map->colors; i++) {
         indexes[i].idx = i;

--- a/pam.h
+++ b/pam.h
@@ -62,6 +62,12 @@
 #  define SSE_ALIGN
 #endif
 
+#ifndef _MSC_VER
+#define LIQ_ARRAY(type, var, count) type var[count]
+#else
+#define LIQ_ARRAY(type, var, count) type* var = (type*)_alloca(sizeof(type)*(count))
+#endif
+
 #if defined(__GNUC__) || defined (__llvm__)
 #define ALWAYS_INLINE __attribute__((always_inline)) inline
 #define NEVER_INLINE __attribute__ ((noinline))


### PR DESCRIPTION
I'm aware of msvc branch, however, with minor modifications master could be used for windows builds with MS compiler.