### PR TITLE
Tweak Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config.mk
+imagequant.pc
 *.lo
 *.o
 *.a

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ SHAREDLIB=libimagequant.$(SOLIBSUFFIX)
 SOVER=0
 ifeq ($(SOLIBSUFFIX),dylib)
 	SHAREDLIBVER=libimagequant.$(SOVER).$(SOLIBSUFFIX)
+	FIX_INSTALL_NAME=install_name_tool -id $(LIBDIR)/$(SHAREDLIBVER) $(DESTDIR)$(LIBDIR)/$(SHAREDLIBVER)
 else
 	SHAREDLIBVER=libimagequant.$(SOLIBSUFFIX).$(SOVER)
+	FIX_INSTALL_NAME=
 endif
 
 JNILIB=libimagequant.jnilib
@@ -24,12 +26,12 @@ JAVACLASSES = org/pngquant/LiqObject.class org/pngquant/PngQuant.class org/pngqu
 JAVAHEADERS = $(JAVACLASSES:.class=.h)
 JAVAINCLUDE = -I'$(JAVA_HOME)/include' -I'$(JAVA_HOME)/include/linux' -I'$(JAVA_HOME)/include/win32' -I'$(JAVA_HOME)/include/darwin'
 
-DISTFILES = $(OBJS:.o=.c) *.h README.md CHANGELOG COPYRIGHT Makefile configure
+DISTFILES = $(OBJS:.o=.c) *.h README.md CHANGELOG COPYRIGHT Makefile configure imagequant.pc.in
 TARNAME = libimagequant-$(VERSION)
 TARFILE = $(TARNAME)-src.tar.bz2
 PKGCONFIG = imagequant.pc
 
-all: static
+all: static shared
 
 static: $(STATICLIB)
 
@@ -55,8 +57,6 @@ $(SHAREDOBJS):
 libimagequant.so: $(SHAREDOBJS)
 	$(CC) -shared -Wl,-soname,$(SHAREDLIBVER) -o $(SHAREDLIBVER) $^ $(LDFLAGS)
 	ln -fs $(SHAREDLIBVER) $(SHAREDLIB)
-	sed -i "s#^prefix=.*#prefix=$(PREFIX)#" $(PKGCONFIG)
-	sed -i "s#^Version:.*#Version: $(VERSION)#" $(PKGCONFIG)
 
 libimagequant.dylib: $(SHAREDOBJS)
 	$(CC) -shared -o $(SHAREDLIBVER) $^ $(LDFLAGS)
@@ -107,26 +107,33 @@ clean:
 
 distclean: clean
 	rm -f config.mk
+	rm -f imagequant.pc
 
-install:
-	[ -d $(DESTDIR)$(LIBDIR) ] || mkdir -p $(DESTDIR)$(LIBDIR)
-	[ -d $(DESTDIR)$(PKGCONFIGDIR) ] || mkdir -p $(DESTDIR)$(PKGCONFIGDIR)
-	[ -d $(DESTDIR)$(INCLUDEDIR) ] || mkdir -p $(DESTDIR)$(INCLUDEDIR)
-	install $(SHAREDLIBVER) $(DESTDIR)$(LIBDIR)/$(SHAREDLIBVER)
-	cp -P $(SHAREDLIB) $(DESTDIR)$(LIBDIR)/$(SHAREDLIB)
-	install imagequant.pc $(DESTDIR)$(PKGCONFIGDIR)/imagequant.pc
-	install libimagequant.h $(DESTDIR)$(INCLUDEDIR)/libimagequant.h
+install: all $(PKGCONFIG)
+	install -d $(DESTDIR)$(LIBDIR)
+	install -d $(DESTDIR)$(PKGCONFIGDIR)
+	install -d $(DESTDIR)$(INCLUDEDIR)
+	install -m 644 $(STATICLIB) $(DESTDIR)$(LIBDIR)/$(STATICLIB)
+	install -m 644 $(SHAREDLIBVER) $(DESTDIR)$(LIBDIR)/$(SHAREDLIBVER)
+	ln -sf $(SHAREDLIBVER) $(DESTDIR)$(LIBDIR)/$(SHAREDLIB)
+	install -m 644 $(PKGCONFIG) $(DESTDIR)$(PKGCONFIGDIR)/$(PKGCONFIG)
+	install -m 644 libimagequant.h $(DESTDIR)$(INCLUDEDIR)/libimagequant.h
+	$(FIX_INSTALL_NAME)
 
 uninstall:
+	rm -f $(DESTDIR)$(LIBDIR)/$(STATICLIB)
 	rm -f $(DESTDIR)$(LIBDIR)/$(SHAREDLIBVER)
 	rm -f $(DESTDIR)$(LIBDIR)/$(SHAREDLIB)
-	rm -f $(DESTDIR)$(PKGCONFIGDIR)/imagequant.pc
+	rm -f $(DESTDIR)$(PKGCONFIGDIR)/$(PKGCONFIG)
 	rm -f $(DESTDIR)$(INCLUDEDIR)/libimagequant.h
 
 config.mk:
 ifeq ($(filter %clean %distclean, $(MAKECMDGOALS)), )
 	./configure
 endif
+
+$(PKGCONFIG): config.mk
+	sed 's|PREFIX|$(PREFIX)|;s|VERSION|$(VERSION)|' < imagequant.pc.in > $(PKGCONFIG)
 
 .PHONY: all static shared clean dist distclean dll java cargo
 .DELETE_ON_ERROR:

--- a/imagequant.pc.in
+++ b/imagequant.pc.in
@@ -1,9 +1,10 @@
-prefix=
+prefix=PREFIX
 includedir=${prefix}/include
-libdir=libdir=${prefix}/lib
+libdir=${prefix}/lib
 
 Name: imagequant
 Description: Small, portable C library for high-quality conversion of RGBA images to 8-bit indexed-color (palette) images.
-Version: 
+URL: https://pngquant.org/lib/
+Version: VERSION
 Libs: -L${libdir} -limagequant
 Cflags: -I${includedir}


### PR DESCRIPTION
* Build static and shared lib for all target
* Install static lib in install target
* Fix shared lib symlink derefercing during install on macOS
* Fix `imagequant.pc` generation for macOS
* Fix duplicate `libdir=` in `imagequant.pc`
* Rename `imagequant.pc` to `imagequant.pc.in`
* Add `imagequant.pc.in` to distfiles
* Add dynamically generated `imagequant.pc` to `.gitignore`
* Install files without execute permissions
* Create install dirs using `install -d` instead of `mkdir -p`
* Update `install_name` for dylib to allow linking with custom prefix

I've tested the changes on macOS 10.13.4 / Xcode 9.3 and Debian Wheezy using Docker.