### PR TITLE
Fix bounds check for setting dithering level

### DIFF
--- a/libimagequant.c
+++ b/libimagequant.c
@@ -1030,7 +1030,7 @@ LIQ_EXPORT LIQ_NONNULL liq_error liq_set_dithering_level(liq_result *res, float 
         res->remapping = NULL;
     }
 
-    if (res->dither_level < 0 || res->dither_level > 1.0f) return LIQ_VALUE_OUT_OF_RANGE;
+    if (dither_level < 0 || dither_level > 1.0f) return LIQ_VALUE_OUT_OF_RANGE;
     res->dither_level = dither_level;
     return LIQ_OK;
 }


### PR DESCRIPTION
Hello! I'm currently developing Python bindings for LIQ (which is a fantastic piece of software, by the way!), and I noticed this bug while creating some unit tests. Currently, you can set invalid dithering levels because liq_set_dithering_level() checks the wrong variable against the minimum and maximum values. (Tested with version 2.12.3, but the same bug is still present in the master branch.) This PR fixes it.