### PR TITLE
Update build.rs

### DIFF
--- a/rust-sys/build.rs
+++ b/rust-sys/build.rs
@@ -23,8 +23,7 @@ fn main() {
     }
 
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("Needs CARGO_CFG_TARGET_ARCH");
-    if target_arch =="x86_64" ||
-       (target_arch == "x86" && cfg!(feature = "sse")) {
+    if target_arch == "x86" && cfg!(feature = "sse") {
         cc.flag(if compiler.is_like_msvc() {"/arch:SSE2"} else {"-msse"});
         cc.define("USE_SSE", Some("1"));
     }


### PR DESCRIPTION
x64 builds don't need `/arch:SSE2` specified

Noticed it on https://github.com/kornelski/pngquant/issues/312#issuecomment-568888500

I only tested x64 builds, and I'm not familiar with rust syntax so let me know if this doesn't do the job.

Noticed it on pngquant msvc branch. Any reason why you don't use the master branch and merge the msvc changes there @kornelski ?