### PR TITLE
initialize likely_colormap_index

### DIFF
--- a/pam.c
+++ b/pam.c
@@ -225,6 +225,9 @@ LIQ_PRIVATE histogram *pam_acolorhashtoacolorhist(const struct acolorhash_table 
     }
     hist->size = j;
     hist->total_perceptual_weight = total_weight;
+    for(unsigned int k=0; k < hist->size; k++) {
+        hist->achv[k].tmp.likely_colormap_index = 0;
+    }
     if (!j) {
         pam_freeacolorhist(hist);
         return NULL;


### PR DESCRIPTION
This is needed to avoid uninitialized usage later on, which is reported by valgrind as shown below.
It seemed like the best place to put it, but I would just like to make sure. Thanks!

    ==11283== Conditional jump or move depends on uninitialised value(s)
    ==11283==    at 0x13D99C: pngquant_quantize (libimagequant.c:2000)
    ==11283==    by 0x1384B8: liq_histogram_quantize_internal (libimagequant.c:1018)
    ==11283==    by 0x138334: liq_image_quantize (libimagequant.c:992)
    ==11283==    by 0x138249: liq_quantize_image (libimagequant.c:970)
    ==11283==    by 0x12679B: image_quantize (image.c:486)
    ==11283==    by 0x126BA8: main (main.c:92)
    ==11283== 
    ==11283== Use of uninitialised value of size 8
    ==11283==    at 0x141A9B: nearest_search (nearest.c:174)
    ==11283==    by 0x1355C6: kmeans_do_iteration (kmeans.c:85)
    ==11283==    by 0x13DAAC: pngquant_quantize (libimagequant.c:2015)
    ==11283==    by 0x1384B8: liq_histogram_quantize_internal (libimagequant.c:1018)
    ==11283==    by 0x138334: liq_image_quantize (libimagequant.c:992)
    ==11283==    by 0x138249: liq_quantize_image (libimagequant.c:970)
    ==11283==    by 0x12679B: image_quantize (image.c:486)
    ==11283==    by 0x126BA8: main (main.c:92)
    ==11283== 
    ==11283== Use of uninitialised value of size 8
    ==11283==    at 0x141D4D: nearest_search (nearest.c:175)
    ==11283==    by 0x1355C6: kmeans_do_iteration (kmeans.c:85)
    ==11283==    by 0x13DAAC: pngquant_quantize (libimagequant.c:2015)
    ==11283==    by 0x1384B8: liq_histogram_quantize_internal (libimagequant.c:1018)
    ==11283==    by 0x138334: liq_image_quantize (libimagequant.c:992)
    ==11283==    by 0x138249: liq_quantize_image (libimagequant.c:970)
    ==11283==    by 0x12679B: image_quantize (image.c:486)
    ==11283==    by 0x126BA8: main (main.c:92)