### PR TITLE
colordifference_stdc: use float as in SSE

### DIFF
--- a/pam.h
+++ b/pam.h
@@ -147,12 +147,12 @@ inline static rgba_pixel f_to_rgb(const float gamma, const f_pixel px)
     };
 }
 
-ALWAYS_INLINE static double colordifference_ch(const double x, const double y, const double alphas);
-inline static double colordifference_ch(const double x, const double y, const double alphas)
+ALWAYS_INLINE static float colordifference_ch(const float x, const float y, const float alphas);
+inline static float colordifference_ch(const float x, const float y, const float alphas)
 {
     // maximum of channel blended on white, and blended on black
     // premultiplied alpha and backgrounds 0/1 shorten the formula
-    const double black = x-y, white = black+alphas;
+    const float black = x-y, white = black+alphas;
     return MAX(black*black, white*white);
 }
 
@@ -172,7 +172,7 @@ inline static float colordifference_stdc(const f_pixel px, const f_pixel py)
     // (px.rgb - px.a) - (py.rgb - py.a)
     // (px.rgb - py.rgb) + (py.a - px.a)
 
-    const double alphas = py.a-px.a;
+    const float alphas = py.a-px.a;
     return colordifference_ch(px.r, py.r, alphas) +
            colordifference_ch(px.g, py.g, alphas) +
            colordifference_ch(px.b, py.b, alphas);


### PR DESCRIPTION
The SSE implementation of the function uses single-precision float, whereas this one goes for.... double all over the place.

Extremely unscientific comparisons on godbolt (https://gcc.godbolt.org/z/oa3hP5ffs) shows that both Clang and GCC do much better generating x64 code when float is used. Other SIMD systems should act similarly, but I can't remember the target names. (For more human-like code in clang, try `-Ofast`. I could add an attribute or some assumes there, but ehhhh... sounds unnecessary.)

PS: It might be a good idea to review other internal uses of `double` too. The two cases left appear to be generally sums and other statistics, which I guess is better with `double`, and `gamma`, which has an external `double` API.