### PR TITLE
Initialize rows using heap for large images

### DIFF
--- a/libimagequant.c
+++ b/libimagequant.c
@@ -2100,7 +2100,7 @@ LIQ_EXPORT LIQ_NONNULL liq_error liq_write_remapped_image(liq_result *result, li
         return LIQ_BUFFER_TOO_SMALL;
     }
 
-    LIQ_ARRAY(unsigned char *, rows, input_image->height);
+    unsigned char **rows = malloc(input_image->height * sizeof(unsigned char *));
     unsigned char *buffer_bytes = buffer;
     for(unsigned int i=0; i < input_image->height; i++) {
         rows[i] = &buffer_bytes[input_image->width * i];

--- a/libimagequant.c
+++ b/libimagequant.c
@@ -2105,7 +2105,10 @@ LIQ_EXPORT LIQ_NONNULL liq_error liq_write_remapped_image(liq_result *result, li
     for(unsigned int i=0; i < input_image->height; i++) {
         rows[i] = &buffer_bytes[input_image->width * i];
     }
-    return liq_write_remapped_image_rows(result, input_image, rows);
+    
+    liq_error err = liq_write_remapped_image_rows(result, input_image, rows);
+    free(rows);
+    return err;
 }
 
 LIQ_EXPORT LIQ_NONNULL liq_error liq_write_remapped_image_rows(liq_result *quant, liq_image *input_image, unsigned char **row_pointers)


### PR DESCRIPTION
This fixes a SIGBUS error when large images are being quantized.

In my scenario, an image whose height exceeded the stack buffer would overflow causing a SIGBUS. This change uses malloc which should put `rows` on the heap instead of the stack.

FWIW I am on Mac OS X 11.5.1 and the stack size configured locally is:
```bash
joshuasager@~  $ ulimit -a | grep "stack size"
stack size                  (kbytes, -s) 8192
```