### PR TITLE
Install library with execute permission

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ install: all $(PKGCONFIG)
 	install -d $(DESTDIR)$(PKGCONFIGDIR)
 	install -d $(DESTDIR)$(INCLUDEDIR)
 	install -m 644 $(STATICLIB) $(DESTDIR)$(LIBDIR)/$(STATICLIB)
-	install -m 644 $(SHAREDLIBVER) $(DESTDIR)$(LIBDIR)/$(SHAREDLIBVER)
+	install -m 755 $(SHAREDLIBVER) $(DESTDIR)$(LIBDIR)/$(SHAREDLIBVER)
 	ln -sf $(SHAREDLIBVER) $(DESTDIR)$(LIBDIR)/$(SHAREDLIB)
 	install -m 644 $(PKGCONFIG) $(DESTDIR)$(PKGCONFIGDIR)/$(PKGCONFIG)
 	install -m 644 libimagequant.h $(DESTDIR)$(INCLUDEDIR)/libimagequant.h


### PR DESCRIPTION
I've been carrying this patch downstream for Fedora for while - rpmlint warns if shared libraries are not executable, and such libraries are not picked up by automatic debuginfo exctraction.