### PR TITLE
Add the cargo-c metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ include = ["COPYRIGHT", "src/*.rs", "*.h", "README.md", "Cargo.toml"]
 readme = "README.md"
 edition = "2018"
 
+[features]
+capi = []
+
 [lib]
 crate-type = ["cdylib", "staticlib", "lib"]
 doctest = false
@@ -29,3 +32,17 @@ thread_local = "1.1.3"
 
 [dev-dependencies]
 lodepng = "3.4.7"
+
+[package.metadata.capi.library]
+version = "0.0.0"
+
+[package.metadata.capi.pkg_config]
+description = "Convert 24/32-bit images to 8-bit palette with alpha channel."
+
+[package.metadata.capi.header]
+name = "libimagequant"
+subdirectory = ""
+generation = false
+
+[package.metadata.capi.install.include]
+asset = [{from = "libimagequant.h"}]


### PR DESCRIPTION
Fixes #68

It produces
```
   |- usr/
      |- local/
         |- include/
            |- imagequant/
               |- libimagequant.h
         |- lib/
            |- pkgconfig/
               |- imagequant.pc
            |- libimagequant.a
            |- libimagequant.{dylib/so}
            |- libimagequant.4.{dylib/so}
            |- libimagequant.4.0.0.{dylib/so}
```
On unix-like and
```
   |- usr/
      |- local/
         |- bin/
            |- imagequant.dll
         |- include/
            |- imagequant/
               |- libimagequant.h
         |- lib/
            |- pkgconfig/
               |- imagequant.pc
            |- imagequant.def
            |- imagequant.dll.a
            |- libimagequant.a
``` 
On windows.