### PR TITLE
Add repr(C) to unions to ensure variants are laid out at the start

### DIFF
--- a/src/hist.rs
+++ b/src/hist.rs
@@ -75,6 +75,7 @@ impl fmt::Debug for HistItem {
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub union HistSortTmp {
     pub mc_sort_value: u32,
@@ -344,6 +345,7 @@ struct TempHistItem {
     cluster_index: u8,
 }
 
+#[repr(C)]
 union RGBAInt {
     rgba: RGBA,
     int: u32,


### PR DESCRIPTION
I found this bug when investigating use cases for the lint proposed https://github.com/rust-lang/rust-clippy/pull/8289#issuecomment-1013914592

If a union doesn't have a `#[repr(C)]` attribute on it, the two variants do *not* have to be laid out both starting at offset 0. It would be perfectly valid to treat that `union` keyword as a `struct` keyword, and then suddenly you're reading uninit data / getting the wrong results.

Source for this: https://doc.rust-lang.org/reference/types/union.html says
> The memory layout of a union is undefined by default, but the `#[repr(...)]` attribute can be used to fix a layout.