### PR TITLE
Fix off by one error in checks introduced in "Allow >256 colors eventually"

### DIFF
--- a/src/remap.rs
+++ b/src/remap.rs
@@ -32,7 +32,7 @@ pub(crate) fn remap_to_palette<'x, 'b: 'x>(image: &mut Image, output_pixels: &'x
     let n = Nearest::new(palette)?;
     let colors = palette.as_slice();
     let palette_len = colors.len();
-    if palette_len > u8::MAX as usize {
+    if palette_len > u8::MAX as usize + 1 {
         return Err(Error::Unsupported);
     }
 
@@ -167,7 +167,7 @@ pub(crate) fn remap_to_palette_floyd(input_image: &mut Image, mut output_pixels:
     let (mut thiserr, mut nexterr) = thiserr_data.split_at_mut(errwidth);
     let n = Nearest::new(&quant.palette)?;
     let palette = quant.palette.as_slice();
-    if palette.len() > u8::MAX as usize {
+    if palette.len() > u8::MAX as usize + 1 {
         return Err(Error::Unsupported);
     }
 


### PR DESCRIPTION
The aforementioned commit introduced some plumbing to allow quantizing to more than 256 colors. However, the guard checks it added to error out if an image is remapped to more than 256 colors incorrectly error out when remapping to exactly 256 colors, as u8::MAX == 255 and 256 > 255.

Fix that by comparing against u8::MAX + 1 instead.