### PR TITLE
fix: 32 bits architecture crash

### DIFF
--- a/src/pal.rs
+++ b/src/pal.rs
@@ -25,7 +25,10 @@ pub const MAX_TRANSP_A: f32 = 255. / 256. * LIQ_WEIGHT_A;
 ///
 /// ARGB layout is important for x86 SIMD.
 /// I've created the newtype wrapper to try a 16-byte alignment, but it didn't improve perf :(
-#[repr(C, align(16))]
+#[cfg_attr(
+    any(target_arch = "x86_64", all(target_feature = "neon", target_arch = "aarch64")),
+    repr(C, align(16))
+)]
 #[derive(Debug, Copy, Clone, Default, PartialEq)]
 #[allow(non_camel_case_types)]
 pub struct f_pixel(pub ARGBF);


### PR DESCRIPTION
When using imagequant on 32 bit env I had this bug: 
crossbeam expects pointers (data) to be aligned on 16 bits (because of this repr(C, align(16))) but on 32 bits arch, we can have pointers (data) aligned on 8 bits