### PR TITLE
fix linking error when compiling C example code

### DIFF
--- a/imagequant-sys/Makefile
+++ b/imagequant-sys/Makefile
@@ -36,7 +36,7 @@ $(JAVAHEADERS): %.h: %.class
 	javah -o $@ $(subst /,., $(patsubst %.class,%,$<)) && touch $@
 
 example: example.c lodepng.h lodepng.c $(STATICLIB)
-	$(CC) -g $(CFLAGS) -Wall example.c $(STATICLIB) -lm -o example
+	$(CC) -g $(CFLAGS) -Wall example.c $(STATICLIB) -lm -lpthread -ldl -o example
 
 lodepng.h:
 	curl -o lodepng.h -L https://raw.githubusercontent.com/lvandeve/lodepng/master/lodepng.h


### PR DESCRIPTION
Added pthread and dl lib for linking
![image](https://github.com/ImageOptim/libimagequant/assets/68238841/711c1d98-91da-404d-8b84-4d292ee718d7)
![image](https://github.com/ImageOptim/libimagequant/assets/68238841/a5638d35-d639-4aa8-8ceb-a5e6400629b9)