### PR TITLE
Let cargo-c auto-detect version from Cargo.toml

### DIFF
--- a/imagequant-sys/Cargo.toml
+++ b/imagequant-sys/Cargo.toml
@@ -29,7 +29,6 @@ libc = "0.2.112"
 
 [package.metadata.capi.library]
 name = "imagequant"
-version = "0.0.0"
 
 [package.metadata.capi.pkg_config]
 name = "imagequant"


### PR DESCRIPTION
This was discovered through https://github.com/lu-zero/cargo-c/issues/345.

This is likely a left-over, the line can be safely removed so cargo-c auto-detects the SONAME as `libimagequant.so.4` instead of `libimagequant.so.0`.

Thanks!