### PR TITLE
fix build warning

### DIFF
--- a/nearest.c
+++ b/nearest.c
@@ -168,10 +168,10 @@ static void vp_search_node(const vp_node *node, const f_pixel *const needle, vp_
 
         if (node->restcount) {
             for(int i=0; i < node->restcount; i++) {
-                const float distance_squared = colordifference(node->rest[i].color, *needle);
-                if (distance_squared < best_candidate->distance_squared && best_candidate->exclude != node->rest[i].idx) {
-                    best_candidate->distance = sqrtf(distance_squared);
-                    best_candidate->distance_squared = distance_squared;
+                const float rest_distance_squared = colordifference(node->rest[i].color, *needle);
+                if (rest_distance_squared < best_candidate->distance_squared && best_candidate->exclude != node->rest[i].idx) {
+                    best_candidate->distance = sqrtf(rest_distance_squared);
+                    best_candidate->distance_squared = rest_distance_squared;
                     best_candidate->idx = node->rest[i].idx;
                 }
             }

--- a/pam.c
+++ b/pam.c
@@ -250,10 +250,10 @@ LIQ_PRIVATE histogram *pam_acolorhashtoacolorhist(const struct acolorhash_table 
     float gamma_lut[256];
     to_f_set_gamma(gamma_lut, gamma);
     for(int i=0; i < hist->size; i++) {
-        int j = hist->boxes[temp[i].cluster].end++;
-        hist->achv[j].acolor = rgba_to_f(gamma_lut, temp[i].color);
-        hist->achv[j].perceptual_weight = temp[i].weight;
-        hist->achv[j].adjusted_weight = temp[i].weight;
+        int k = hist->boxes[temp[i].cluster].end++;
+        hist->achv[k].acolor = rgba_to_f(gamma_lut, temp[i].color);
+        hist->achv[k].perceptual_weight = temp[i].weight;
+        hist->achv[k].adjusted_weight = temp[i].weight;
     }
     free(temp);
 


### PR DESCRIPTION
After adding `-Werror=shadow` to the 2.x branch, I encountered a compilation error.

``` bash
nearest.c: In function ‘vp_search_node’:
nearest.c:171:29: error: declaration of ‘distance_squared’ shadows a previous local [-Werror=shadow]
  171 |                 const float distance_squared = colordifference(node->rest[i].color, *needle);
      |                             ^~~~~~~~~~~~~~~~
nearest.c:160:21: note: shadowed declaration is here
  160 |         const float distance_squared = colordifference(node->vantage_point, *needle);
      |                     ^~~~~~~~~~~~~~~~
pam.c: In function ‘pam_acolorhashtoacolorhist’:
pam.c:253:13: error: declaration of ‘j’ shadows a previous local [-Werror=shadow]
  253 |         int j = hist->boxes[temp[i].cluster].end++;
      |             ^
pam.c:215:18: note: shadowed declaration is here
  215 |     unsigned int j=0;
      |                  ^
nearest.c: In function ‘vp_search_node’:
pam.c: In function ‘pam_acolorhashtoacolorhist’:
pam.c:253:13: error: declaration of ‘j’ shadows a previous local [-Werror=shadow]
  253 |         int j = hist->boxes[temp[i].cluster].end++;
      |             ^
pam.c:215:18: note: shadowed declaration is here
  215 |     unsigned int j=0;
      |                  ^
nearest.c:171:29: error: declaration of ‘distance_squared’ shadows a previous local [-Werror=shadow]
  171 |                 const float distance_squared = colordifference(node->rest[i].color, *needle);
      |                             ^~~~~~~~~~~~~~~~
nearest.c:160:21: note: shadowed declaration is here
  160 |         const float distance_squared = colordifference(node->vantage_point, *needle);
      |                     ^~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
```