### PR TITLE
Serialization/Deserialization of `QuantizationResult` using Serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,12 @@ rgb = { version = "0.8.47", default-features = false, features = ["bytemuck", "s
 rayon = { version = "1.10.0", optional = true }
 thread_local = { version = "1.1.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 serde_arrays = "0.2.0"
 once_cell = "1.19.0"
 
 [dev-dependencies]
 lodepng = "3.10"
+serde_json = "1.0"
 
 [workspace]
 members = ["imagequant-sys", "imagequant-sys/c_test"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,13 @@ panic = "abort"
 doctest = false
 
 [dependencies]
-arrayvec = "0.7.4"
-rgb = { version = "0.8.47", default-features = false, features = ["bytemuck"] }
+arrayvec = { version = "0.7.4", features = ["serde"] }
+rgb = { version = "0.8.47", default-features = false, features = ["bytemuck", "serde"] }
 rayon = { version = "1.10.0", optional = true }
 thread_local = { version = "1.1.8", optional = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_arrays = "0.2.0"
 once_cell = "1.19.0"
 
 [dev-dependencies]

--- a/imagequant-sys/Cargo.toml
+++ b/imagequant-sys/Cargo.toml
@@ -24,6 +24,8 @@ name = "imagequant_sys"
 
 [dependencies]
 imagequant = { path = "..", version = "4.2.1", default-features = false, features = ["_internal_c_ffi"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 bitflags = "2.5"
 libc = "0.2.153"
 

--- a/imagequant-sys/libimagequant.h
+++ b/imagequant-sys/libimagequant.h
@@ -127,6 +127,9 @@ LIQ_EXPORT liq_error liq_set_output_gamma(liq_result* res, double gamma) LIQ_NON
 LIQ_EXPORT LIQ_USERESULT double liq_get_output_gamma(const liq_result *result) LIQ_NONNULL;
 
 LIQ_EXPORT LIQ_USERESULT const liq_palette *liq_get_palette(liq_result *result) LIQ_NONNULL;
+LIQ_EXPORT liq_error liq_result_json_serialize(const liq_result *result, char** json) LIQ_NONNULL;
+LIQ_EXPORT liq_error liq_result_json_deserialize(const char* json, liq_result **result_output) LIQ_NONNULL;
+LIQ_EXPORT void liq_result_json_destroy(char* json) LIQ_NONNULL;
 
 LIQ_EXPORT liq_error liq_write_remapped_image(liq_result *result, liq_image *input_image, void *buffer, size_t buffer_size) LIQ_NONNULL;
 LIQ_EXPORT liq_error liq_write_remapped_image_rows(liq_result *result, liq_image *input_image, unsigned char **row_pointers) LIQ_NONNULL;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,16 @@ fn test_fixed_colors() {
         h.add_fixed_color(RGBA::new(f, f, f, 255), 0.).unwrap();
     }
     let mut r = h.quantize(&attr).unwrap();
+    let mut jsonr: QuantizationResult =
+        serde_json::from_str(serde_json::to_string(&r).unwrap().as_str()).unwrap();
+    assert_eq!(r.dither_level, jsonr.dither_level);
+
     let pal = r.palette();
+    let palr = jsonr.palette();
+    assert_eq!(pal.len(), palr.len());
+    for c in 0..pal.len() {
+        assert_eq!(pal[c], palr[c]);
+    }
 
     for (i, c) in (200..255).enumerate() {
         assert_eq!(pal[i], RGBA::new(c, c, c, 255));

--- a/src/pal.rs
+++ b/src/pal.rs
@@ -1,6 +1,7 @@
 use crate::OrdFloat;
 use arrayvec::ArrayVec;
 use rgb::prelude::*;
+use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 /// 8-bit RGBA in sRGB. This is the only color format *publicly* used by the library.
@@ -29,7 +30,7 @@ pub const MAX_TRANSP_A: f32 = 255. / 256. * LIQ_WEIGHT_A;
     any(target_arch = "x86_64", all(target_feature = "neon", target_arch = "aarch64")),
     repr(C, align(16))
 )]
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 pub struct f_pixel(pub ARGBF);
 
@@ -171,7 +172,7 @@ impl From<ARGBF> for f_pixel {
 }
 
 /// To keep the data dense, `is_fixed` is stuffed into the sign bit
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PalPop(f32);
 
 impl PalPop {
@@ -216,7 +217,7 @@ pub type PalLen = u16;
 pub(crate) const MAX_COLORS: usize = if PalIndex::MAX == 255 { 256 } else { 2048 };
 
 /// A palette of premultiplied ARGB 4xf32 colors in internal gamma
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct PalF {
     colors: ArrayVec<f_pixel, MAX_COLORS>,
     pops: ArrayVec<PalPop, MAX_COLORS>,
@@ -345,11 +346,12 @@ pub fn gamma_lut(gamma: f64) -> [f32; 256] {
 /// Not used in the Rust API.
 /// RGBA colors obtained from [`QuantizationResult`](crate::QuantizationResult)
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Palette {
     /// Number of used colors in the `entries`
     pub count: std::os::raw::c_uint,
     /// The colors, up to `count`
+    #[serde(with = "serde_arrays")]
     pub entries: [RGBA; MAX_COLORS],
 }
 

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -10,14 +10,17 @@ use crate::remap::{remap_to_palette, remap_to_palette_floyd};
 use crate::seacow::RowBitmapMut;
 use crate::OrdFloat;
 use arrayvec::ArrayVec;
+use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
 use std::fmt;
 use std::mem::MaybeUninit;
 
 /// Remapping step, computed from [`Attributes::quantize()`]
+#[derive(Serialize, Deserialize)]
 pub struct QuantizationResult {
     remapped: Option<Box<Remapped>>,
     pub(crate) palette: PalF,
+    #[serde(skip)]
     progress_callback: Option<Box<dyn Fn(f32) -> ControlFlow + Send + Sync>>,
     pub(crate) int_palette: Palette,
     pub(crate) dither_level: f32,

--- a/src/remap.rs
+++ b/src/remap.rs
@@ -8,18 +8,19 @@ use crate::rayoff::*;
 use crate::rows::{temp_buf, DynamicRows};
 use crate::seacow::{RowBitmap, RowBitmapMut};
 use crate::CacheLineAlign;
+use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::mem::MaybeUninit;
 
 #[repr(u8)]
-#[derive(Eq, PartialEq, Clone, Copy)]
+#[derive(Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum DitherMapMode {
     None = 0,
     Enabled = 1,
     Always = 2,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct Remapped {
     pub(crate) int_palette: Palette,
     pub(crate) palette_error: Option<f64>,

--- a/src/rows.rs
+++ b/src/rows.rs
@@ -158,7 +158,7 @@ impl<'pixels, 'rows> DynamicRows<'pixels, 'rows> {
     }
 
     pub fn prepare_iter(&mut self, temp_row: &mut [MaybeUninit<RGBA>], allow_steamed: bool) -> Result<(), Error> {
-        debug_assert_eq!(temp_row.len(), self.width as _);
+        debug_assert_eq!(temp_row.len(), self.width as usize);
 
         if self.f_pixels.is_some() || (allow_steamed && self.should_use_low_memory()) {
             return Ok(());


### PR DESCRIPTION
This pull request adds the ability to serialize/deserialize `QuantizationResult` (and its components, apart from the progress callback) using Serde and adds JSON serialization/deserialization functions to the C interface.

Adding serialization extends the ability to re-use the same quantization result for multiple images, which is a feature advertised in the documentation of `liq_write_remapped_image` in the C interface, beyond a single execution of the program that generated the quantization result. This is essential for applications such as training image restoration networks with on-the-fly degradations, where the same quantization result is applied to the same image with various pre-applied degradations (such as noise, blurring, etc.) and repeatedly performing full quantizations is prohibitively expensive (a full re-computation for one dataset I have been using takes more than an hour).

The only downside of this change that I can see is that it increases the size of the shared C library from 596.6 KiB to 684.6 KiB on my Arch Linux machine, an increase of less than 90 KiB or about 15%, which I think is quite a justifiable increase.

I am happy to make any changes necessary to merge this PR, e.g. by introducing a feature flag to the Rust library, although the inclusion in the C interface is essential for my use. If there is interest in this PR, analogous functionality should be added to the other interfaces as well (I could do the Java interface, but I am not familiar with C#).