### PR TITLE
Add `liq_result_from_palette` to the C interface

### DIFF
--- a/imagequant-sys/libimagequant.h
+++ b/imagequant-sys/libimagequant.h
@@ -121,6 +121,7 @@ LIQ_EXPORT void liq_image_destroy(liq_image *img) LIQ_NONNULL;
 
 LIQ_EXPORT LIQ_USERESULT liq_error liq_histogram_quantize(liq_histogram *const input_hist, liq_attr *const options, liq_result **result_output) LIQ_NONNULL;
 LIQ_EXPORT LIQ_USERESULT liq_error liq_image_quantize(liq_image *const input_image, liq_attr *const options, liq_result **result_output) LIQ_NONNULL;
+LIQ_EXPORT LIQ_USERESULT liq_error liq_result_from_palette(const liq_attr *options, const liq_color *palette, unsigned int palette_size, double gamma, liq_result **result_output) LIQ_NONNULL;
 
 LIQ_EXPORT liq_error liq_set_dithering_level(liq_result *res, float dither_level) LIQ_NONNULL;
 LIQ_EXPORT liq_error liq_set_output_gamma(liq_result* res, double gamma) LIQ_NONNULL;


### PR DESCRIPTION
Exposing this function through the C interface is more convenient than re-writing `QuantizationResult::from_palette` in C and would provide a clear way for re-using a palette between program runs for new users of the C interface (if documented).

I did not get the Java wrapper to compile and I am not familiar with C#, so I did not touch those interfaces.