### PR TITLE
Replace platform-specific SIMD with portable wide crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ doctest = false
 [dependencies]
 arrayvec = { version = "0.7.4", default-features = false }
 rgb = { version = "0.8.47", default-features = false, features = ["bytemuck"] }
+wide = { version = "1.1.1", default-features = false }
 rayon = { version = "1.10.0", optional = true }
 thread_local = { version = "1.1.8", optional = true }
 # Used only in no_std

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -93,7 +93,7 @@ impl Kmeans {
         self.weighed_diff_sum += batch.iter_mut().map(|item| {
             let px = item.color;
             let (matched, mut diff) = n.search(&px, item.likely_palette_index());
-            item.tmp.likely_palette_index = matched;
+            item.tmp = matched as u32;
             if adjust_weight {
                 let remapped = colors[matched as usize];
                 let (_, new_diff) = n.search(&f_pixel(px.0 + px.0 - remapped.0), matched);

--- a/src/mediancut.rs
+++ b/src/mediancut.rs
@@ -141,11 +141,7 @@ fn qsort_pivot(base: &[HistItem]) -> usize {
         return len / 2;
     }
     let mut pivots = [8, len / 2, len - 1];
-    // LLVM can't see it's in bounds :(
-    pivots.sort_unstable_by_key(move |&idx| unsafe {
-        debug_assert!(base.get(idx).is_some());
-        base.get_unchecked(idx)
-    }.mc_sort_value());
+    pivots.sort_unstable_by_key(move |&idx| base[idx].mc_sort_value());
     pivots[1]
 }
 

--- a/src/mediancut.rs
+++ b/src/mediancut.rs
@@ -96,7 +96,7 @@ impl<'hist> MBox<'hist> {
             let chans: [f32; 4] = rgb::bytemuck::cast(item.color.0);
             // Only the first channel really matters. But other channels are included, because when trying median cut
             // many times with different histogram weights, I don't want sort randomness to influence the outcome.
-            item.tmp.mc_sort_value = (u32::from((chans[channels[0].chan] * 65535.) as u16) << 16)
+            item.tmp = (u32::from((chans[channels[0].chan] * 65535.) as u16) << 16)
                 | u32::from(((chans[channels[2].chan] + chans[channels[1].chan] / 2. + chans[channels[3].chan] / 4.) * 65535.) as u16); // box will be split to make color_weight of each side even
         }
     }
@@ -252,7 +252,7 @@ impl<'hist> MedianCutter<'hist> {
         let mut palette = PalF::new();
 
         for (i, mbox) in self.boxes.iter_mut().enumerate() {
-            mbox.colors.iter_mut().for_each(move |a| a.tmp.likely_palette_index = i as _);
+            mbox.colors.iter_mut().for_each(move |a| a.tmp = i as _);
 
             // store total color popularity (perceptual_weight is approximation of it)
             let pop = mbox.colors.iter().map(|a| f64::from(a.perceptual_weight)).sum::<f64>();


### PR DESCRIPTION
## Summary
- Replace platform-specific SSE2/NEON intrinsics in `f_pixel::diff()` with portable `wide::f32x4`
- Remove `HistSortTmp` union in favor of plain `u32` (union was unnecessary since `PalIndex` fits in `u32`)
- Remove unnecessary `get_unchecked` in `qsort_pivot` (3 bounds checks is negligible overhead)

## Details
The `diff()` function had three separate implementations using unsafe intrinsics:
- `#[cfg(target_arch = "x86_64")]` with SSE2
- `#[cfg(target_arch = "aarch64")]` with NEON
- Scalar fallback

Now there's a single portable implementation using `wide::f32x4` that compiles to equivalent SIMD on both architectures. A scalar reference implementation is retained under `#[cfg(test)]` with a brute-force comparison test that verifies both implementations match across edge cases.

## Test plan
- [x] All existing tests pass
- [x] New `diff_simd_matches_scalar` test verifies SIMD matches scalar reference
- [x] `cargo clippy` passes